### PR TITLE
ゲーム情報の編集機能を実装

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -1,4 +1,6 @@
 class GamesController < ApplicationController
+  before_action :set_game, only: [:show, :edit, :update]
+
   def index
     @games = Game.page(params[:page]).per(10).order("created_at DESC")
   end
@@ -17,12 +19,26 @@ class GamesController < ApplicationController
   end
 
   def show
-    @game = Game.find(params[:id])
+  end
+
+  def edit
+  end
+
+  def update
+    if @game.update(game_params)
+      redirect_to game_path(@game)
+    else
+      render :edit
+    end
   end
 
   private
 
   def game_params
     params.require(:game).permit(:title, :description, :metascore)
+  end
+
+  def set_game
+    @game = Game.find(params[:id])
   end
 end

--- a/app/views/games/edit.html.erb
+++ b/app/views/games/edit.html.erb
@@ -1,7 +1,7 @@
 <%= render "shared/header" %>
 
 <div class="ui main text container">
-  <h1 class="ui header">Add Game</h1>
+  <h1 class="ui header">Edit Information</h1>
 
   <%= form_with model: @game, local: true ,class: "ui form error" do |f| %>
     <%= render 'shared/error_messages', model: f.object %>
@@ -17,6 +17,6 @@
       <%= f.label :metascore, 'Metascore:' %>
       <%= f.text_field :metascore %>
     </div>
-    <%= f.submit 'Create Game', class: "ui right floated button" %>
+    <%= f.submit 'Update Game', class: "ui right floated button" %>
   <% end %>
 </div>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -1,6 +1,7 @@
 <%= render "shared/header" %>
 
 <div class="ui main text container">
+  <%= link_to 'Edit', edit_game_path, class: "ui right floated button" %>
   <h1 class="ui header"><%= @game.title %></h1>
   <%= image_tag "noimage.png", class: "ui centered medium image" %>
   <p><%= @game.description %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Rails.application.routes.draw do
   root to: "games#index"
-  resources :games, only: [:index, :new, :create, :show]
+  resources :games, only: [:index, :new, :create, :show, :edit, :update]
 end


### PR DESCRIPTION
# What
- ゲーム情報の編集ページを作成
- gamesコントローラーにedit, updateアクションを定義
- 詳細ページに編集ページへのリンクを追加

# Why
ゲーム情報の編集機能を実装するため

